### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ npx @flowcore/platform-mcp-server --username <username> --pat <pat>
 
 Replace `<username>` and `<pat>` with your Flowcore username and PAT (Personal Access Token).
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/flowcore-mcp-flowcore-platform).
+
 ## Installation
 
 If you prefer to install the package globally:

--- a/README.md
+++ b/README.md
@@ -16,10 +16,6 @@ npx @flowcore/platform-mcp-server --username <username> --pat <pat>
 
 Replace `<username>` and `<pat>` with your Flowcore username and PAT (Personal Access Token).
 
-## Hosted deployment
-
-A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/flowcore-mcp-flowcore-platform).
-
 ## Installation
 
 If you prefer to install the package globally:
@@ -61,6 +57,10 @@ Run the built project:
 ```bash
 node dist/cli.js --username <username> --pat <pat>
 ```
+
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/flowcore-mcp-flowcore-platform).
 
 ## Environment Variables
 


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/flowcore-mcp-flowcore-platform).